### PR TITLE
Can you add our work OmniKV (ICLR25) ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ This repository contains a regularly updated paper list for **Efficient Reasonin
   *Pranjal Aggarwal, Sean Welleck*. [[pdf](https://www.arxiv.org/pdf/2503.04697)], [[code](https://github.com/cmu-l3/l1)], [[homepage](https://cmu-l3.github.io/l1/)], 2025.03. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/L1-blue) ![](https://img.shields.io/badge/Length_Control-green)
 - **PENCIL: Long Thoughts with Short Memory**  
   *PENCIL: Long Thoughts with Short Memory*. [[pdf](https://arxiv.org/pdf/2503.14337)], 2025.03. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/PENCIL-blue) ![](https://img.shields.io/badge/Intermediate_CoT_Reduction-green)
+- **OmniKV: Dynamic Context Selection for Efficient Long-Context LLMs**  
+  *Jitai Hao, Yuke Zhu, Tian Wang, Jun Yu, Xin Xin, Bo Zheng, Zhaochun Ren, Sheng Guo*. [[pdf](https://openreview.net/forum?id=ulCAPXYXfa)], 2025.03. ![](https://img.shields.io/badge/ICLR2025-orange)
 
 ### Benchmarks
 


### PR DESCRIPTION
I would like to ask you to include our recent work, [OmniKV: Dynamic Context Selection for Efficient Long-Context LLMs](https://openreview.net/forum?id=ulCAPXYXfa) (ICLR 2025).

In this paper, we propose a method for accelerating long-text inference without discarding tokens, and we verify the importance of this token-preserving feature in Chain-of-Thought (CoT) reasoning. We conducted preliminary experiments on some simple CoT-related tasks.

You may assess whether our work is relevant to the collection. Thank you very much!